### PR TITLE
Added refresh tokens support

### DIFF
--- a/Auth0Client.iOS/Auth0Client.iOS.cs
+++ b/Auth0Client.iOS/Auth0Client.iOS.cs
@@ -18,15 +18,22 @@ namespace Auth0.SDK
 		/// <param name="connection" type="string">
 		/// The name of the connection to use in Auth0. Connection defines an Identity Provider.
 		/// </param>
+		/// <param name="withRefreshToken" type="bool">
+		/// Specifies if it should return a refresh token or not.
+		/// </param>
+		/// <param name="deviceName" type="string">
+		/// The name of the device to register the refresh token in the Auth0 dashboard.
+		/// </param>
 		/// <param name="scope" type="string">
 		/// Space delimited, case sensitive list of OAuth 2.0 scope values.
 		/// </param>
 		/// <returns>
 		/// Task that will complete when the user has finished authentication.
 		/// </returns>
-		public Task<Auth0User> LoginAsync (UIViewController viewController, string connection = "", string scope = "openid")
+        public Task<Auth0User> LoginAsync(UIViewController viewController, string connection = "", bool withRefreshToken = false,
+			string deviceName = "", string scope = "openid")
 		{
-			return this.SendLoginAsync(default(RectangleF), viewController, connection, scope);
+			return this.SendLoginAsync(default(RectangleF), viewController, connection, scope, withRefreshToken, deviceName);
 		}
 
 		/// <summary>
@@ -41,15 +48,22 @@ namespace Auth0.SDK
 		/// <param name="connection" type="string">
 		/// The name of the connection to use in Auth0. Connection defines an Identity Provider.
 		/// </param>
+		/// <param name="withRefreshToken" type="bool">
+		/// Specifies if it should return a refresh token or not.
+		/// </param>
+		/// <param name="deviceName" type="string">
+		/// The name of the device to register the refresh token in the Auth0 dashboard.
+		/// </param>
 		/// <param name="scope" type="string">
 		/// Space delimited, case sensitive list of OAuth 2.0 scope values.
 		/// </param>
 		/// <returns>
 		/// Task that will complete when the user has finished authentication.
 		/// </returns>
-		public Task<Auth0User> LoginAsync (RectangleF rectangle, UIView view, string connection = "", string scope = "openid")
+        public Task<Auth0User> LoginAsync(RectangleF rectangle, UIView view, string connection = "", bool withRefreshToken = false,
+			string deviceName = "", string scope = "openid")
 		{
-			return this.SendLoginAsync(rectangle, view, connection, scope);
+			return this.SendLoginAsync(rectangle, view, connection, scope, withRefreshToken, deviceName);
 		}
 
 		/// <summary>
@@ -61,22 +75,42 @@ namespace Auth0.SDK
 		/// <param name="connection" type="string">
 		/// The name of the connection to use in Auth0. Connection defines an Identity Provider.
 		/// </param>
+		/// <param name="withRefreshToken" type="bool">
+		/// Specifies if it should return a refresh token or not.
+		/// </param>
+		/// <param name="deviceName" type="string">
+		/// The name of the device to register the refresh token in the Auth0 dashboard.
+		/// </param>
 		/// <param name="scope" type="string">
 		/// Space delimited, case sensitive list of OAuth 2.0 scope values.
 		/// </param>
 		/// <returns>
 		/// Task that will complete when the user has finished authentication.
 		/// </returns>
-		public Task<Auth0User> LoginAsync (UIBarButtonItem barButtonItem, string connection = "", string scope = "openid")
+		public Task<Auth0User> LoginAsync (UIBarButtonItem barButtonItem, string connection = "" , bool withRefreshToken = false, 
+			string deviceName = "", string scope = "openid")
 		{
-			return this.SendLoginAsync(default(RectangleF), barButtonItem, connection, scope);
+			return this.SendLoginAsync(default(RectangleF), barButtonItem, connection, scope, withRefreshToken, deviceName);
 		}
 
-		private Task<Auth0User> SendLoginAsync(RectangleF rect, object view, string connection, string scope)
+        private static string IncreaseScopeWithOfflineAccess(bool withRefreshToken, string scope)
+        {
+            if (withRefreshToken && !scope.Contains("offline_access"))
+            {
+                scope += " offline_access";
+            }
+            return scope;
+        }
+
+		private Task<Auth0User> SendLoginAsync(RectangleF rect, object view, string connection,
+			string scope, bool withRefreshToken, string deviceName = "")
 		{
 			// Launch server side OAuth flow using the GET endpoint
+            scope = IncreaseScopeWithOfflineAccess(withRefreshToken, scope);
+
 			var tcs = new TaskCompletionSource<Auth0User> ();
-			var auth = this.GetAuthenticator (connection, scope);
+			var auth = this.GetAuthenticator (connection, scope, deviceName);
+
 
 			UIViewController c = auth.GetUI();
 
@@ -99,6 +133,7 @@ namespace Auth0.SDK
 
 			auth.Completed += (o, e) =>
 			{
+
 				if (controller != null) {
 					controller.DismissViewController (true, null);
 				}

--- a/Auth0Client/Auth0Client.cs
+++ b/Auth0Client/Auth0Client.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xamarin.Auth;
+using System.Security.Policy;
 
 namespace Auth0.SDK
 {
@@ -14,7 +15,7 @@ namespace Auth0.SDK
 	/// </summary>
 	public partial class Auth0Client
 	{
-		private const string AuthorizeUrl = "https://{0}/authorize?client_id={1}&redirect_uri={2}&response_type=token&connection={3}&scope={4}";
+		private const string AuthorizeUrl = "https://{0}/authorize/?client_id={1}&redirect_uri={2}&response_type=token&connection={3}&scope={4}";
 		private const string LoginWidgetUrl = "https://{0}/login/?client={1}&redirect_uri={2}&response_type=token&scope={3}";
 		private const string ResourceOwnerEndpoint = "https://{0}/oauth/ro";
 		private const string DelegationEndpoint = "https://{0}/delegation";
@@ -47,8 +48,9 @@ namespace Auth0.SDK
 		/// <param name="connection" type="string">The name of the connection to use in Auth0. Connection defines an Identity Provider.</param>
 		/// <param name="userName" type="string">User name.</param>
 		/// <param name="password type="string"">User password.</param>
-		public Task<Auth0User> LoginAsync(string connection, string userName, string password)
+		public Task<Auth0User> LoginAsync(string connection, string userName, string password, bool includeRefreshToken = false)
 		{
+
 			var endpoint = string.Format (ResourceOwnerEndpoint, this.domain);
 			var parameters = new Dictionary<string, string> 
 			{
@@ -57,8 +59,12 @@ namespace Auth0.SDK
 				{ "username", userName },
 				{ "password", password },
 				{ "grant_type", "password" },
-				{ "scope", "openid profile" }
 			};
+
+			if (includeRefreshToken)
+				parameters.Add ("scope", "openid profile offline_access");
+			else
+				parameters.Add ("scope", "openid profile");
 
 			var request = new Request ("POST", new Uri(endpoint), parameters);
 			return request.GetResponseAsync ().ContinueWith<Auth0User>(t => 
@@ -90,13 +96,47 @@ namespace Auth0.SDK
 			});
 		}
 
+        /// <summary>
+        /// Renews the idToken (JWT)
+        /// </summary>
+        /// <returns>The refreshed token.</returns>
+		/// <param name="targetClientId" type="string">The target client id. If null, the default client id is used.</param>
+        /// <param name="refreshToken" type="string">The refresh token to use. If null, the logged in users token will be used.</param>
+        /// <param name="options">Additional parameters.</param>
+        public async Task<JObject> RefreshToken(
+            string targetClientId = "",
+            string refreshToken = "",
+            Dictionary<string, string> options = null)
+        {
+            var emptyToken = string.IsNullOrEmpty(refreshToken);
+            if (emptyToken && this.CurrentUser != null && string.IsNullOrEmpty(this.CurrentUser.RefreshToken))
+            {
+                throw new InvalidOperationException(
+                    "The current user's refresh token could not be retrieved or no refresh token was provided as parameter.");
+            }
+			if (String.IsNullOrEmpty (targetClientId)) {
+				targetClientId = this.clientId;
+			}
+			if (string.IsNullOrEmpty (refreshToken)) {
+				refreshToken = this.CurrentUser.RefreshToken;
+			}
+
+            return await this.GetDelegationToken(
+                targetClientId: targetClientId,
+				refreshToken: refreshToken,
+                options: options);
+        }
+
 		/// <summary>
 		/// Get a delegation token.
 		/// </summary>
 		/// <returns>Delegation token result.</returns>
-		/// <param name="targetClientId">Target client ID.</param>
+		/// <param name="refreshToken" type="string">The refresh token to use. If empty, normal delegation endpoint will be called.</param>
+		/// <param name="targetClientId" type="string">Target client ID.</param>
 		/// <param name="options">Custom parameters.</param>
-		public Task<JObject> GetDelegationToken(string targetClientId, IDictionary<string, string> options = null)
+		public Task<JObject> GetDelegationToken(string targetClientId,
+            string refreshToken = "",
+            IDictionary<string, string> options = null)
 		{
 			var id_token = string.Empty;
 			options = options ?? new Dictionary<string, string> ();
@@ -105,13 +145,15 @@ namespace Auth0.SDK
 			if (options.ContainsKey ("id_token")) {
 				id_token = options ["id_token"];
 				options.Remove ("id_token");
-			} else {
-				id_token = this.CurrentUser.IdToken;
+			}
+            else {
+				if(this.CurrentUser != null)
+					id_token = this.CurrentUser.IdToken;
 			}
 
-			if (string.IsNullOrEmpty (id_token)) {
+			if (string.IsNullOrEmpty (id_token) && string.IsNullOrEmpty(refreshToken)) {
 				throw new InvalidOperationException (
-					"You need to login first or specify a value for id_token parameter.");
+					"You need to login first or specify a value for id_token or refreshToken parameter.");
 			}
 
 			var endpoint = string.Format (DelegationEndpoint, this.domain);
@@ -120,8 +162,15 @@ namespace Auth0.SDK
 				{ "grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer" },
 				{ "id_token", id_token },
 				{ "target", targetClientId },
-				{ "client_id", this.clientId }
+				{ "client_id", this.clientId },
 			};
+
+			if (!String.IsNullOrEmpty (refreshToken)) {
+				//token specified, so use that style of delegation
+				parameters.Add ("refresh_token", refreshToken);
+				parameters.Add ("api_type", "app");
+				parameters.Remove ("id_token");
+			} 
 
 			// custom parameters
 			foreach (var option in options) {
@@ -134,7 +183,25 @@ namespace Auth0.SDK
 					try
 					{
 						var text = t.Result.GetResponseText();
-						return JObject.Parse(text);
+						var data = JObject.Parse(text);
+
+						//successfull delegate token
+						if(data.Count > 0){
+							//grab the id and set it as the current users id.
+							var id = data.Value<string>("id_token");
+
+							if(this.CurrentUser != null)
+								this.CurrentUser.IdToken = id;
+							else
+							{
+								this.CurrentUser = new Auth0User(){
+									IdToken = id,
+									RefreshToken = refreshToken
+								};
+							}
+						}
+
+						return  data;
 					}
 					catch (Exception)
 					{
@@ -158,7 +225,8 @@ namespace Auth0.SDK
 		/// <returns>The authenticator.</returns>
 		/// <param name="connection">Connection name.</param>
 		/// <param name="scope">OpenID scope.</param>
-		protected virtual WebRedirectAuthenticator GetAuthenticator(string connection, string scope)
+		/// <param name="deviceName">The device name to use if gettting a refresh token.</param>
+		protected virtual WebRedirectAuthenticator GetAuthenticator(string connection, string scope, string deviceName = "")
 		{
 			// Generate state to include in startUri
 			var chars = new char[16];
@@ -172,6 +240,10 @@ namespace Auth0.SDK
 				string.Format(AuthorizeUrl, this.domain, this.clientId, Uri.EscapeDataString(redirectUri), connection, scope) :
 				string.Format(LoginWidgetUrl, this.domain, this.clientId, Uri.EscapeDataString(redirectUri), scope);
 
+			if (!String.IsNullOrEmpty(deviceName))
+			{
+				authorizeUri += string.Format("&device={0}", Uri.EscapeDataString(deviceName));
+            }
 			var state = new string (chars);
 			var startUri = new Uri (authorizeUri + "&state=" + state);
 			var endUri = new Uri (redirectUri);
@@ -197,7 +269,6 @@ namespace Auth0.SDK
 						{
 							throw new InvalidOperationException(text);
 						}
-
 						accountProperties.Add("profile", text);
 					}
 					catch (Exception ex)
@@ -206,7 +277,8 @@ namespace Auth0.SDK
 					}
 					finally
 					{
-						this.CurrentUser = new Auth0User(accountProperties);
+						var user = new Auth0User(accountProperties);
+						this.CurrentUser = user;
 					}
 				}).Wait();
 		}

--- a/Auth0Client/Auth0User.cs
+++ b/Auth0Client/Auth0User.cs
@@ -16,13 +16,19 @@ namespace Auth0.SDK
 			this.Auth0AccessToken = accountProperties.ContainsKey("access_token") ? accountProperties["access_token"] : string.Empty;
 			this.IdToken = accountProperties.ContainsKey("id_token") ? accountProperties["id_token"] : string.Empty;
 			this.Profile = accountProperties.ContainsKey("profile") ? accountProperties["profile"].ToJson() : null;
+			this.RefreshToken = accountProperties.ContainsKey("refresh_token") ? accountProperties["refresh_token"] : string.Empty;
+
 		}
 
 		public string Auth0AccessToken { get; set; }
 
 		public string IdToken { get; set; }
 
+        public string RefreshToken { get; set; }
+
+
 		public JObject Profile { get; set; }
+
 	}
 
 	internal static class Extensions

--- a/samples/Auth0Client.iOS.Sample/Auth0Client_iOS_SampleViewController.cs
+++ b/samples/Auth0Client.iOS.Sample/Auth0Client_iOS_SampleViewController.cs
@@ -46,14 +46,35 @@ namespace Auth0Client.iOS.Sample
 			return (toInterfaceOrientation != UIInterfaceOrientation.PortraitUpsideDown);
 		}
 
+		private void RefreshUserId()
+		{
+			// Show loading animation
+			this.loadingOverlay = new LoadingOverlay (UIScreen.MainScreen.Bounds);
+			this.View.Add (this.loadingOverlay);
+
+			if (this.client.CurrentUser != null) {
+				//if logged in, refresh token.
+				this.client.RefreshToken ()
+					.ContinueWith (
+					task => this.ShowResult (this.client.CurrentUser), this.scheduler);
+
+			} else {
+				//no user logged in, so show error in results
+				SetResultText ("You must be signed in for this feature to work.");
+			}
+		}
+	
+
 		private void LoginWithWidgetButtonClick ()
 		{
 			// This will show all connections enabled in Auth0, and let the user choose the identity provider
-			this.client.LoginAsync (this)					// current controller
-						.ContinueWith(
-							task => this.ShowResult (task), 
-							this.scheduler);
+			this.client.LoginAsync (this, // current controller
+				withRefreshToken:true, deviceName: "MyTestDevice") //refresh token support. device needed if using refresh.
+				.ContinueWith(
+					task => this.ShowResult (task), 
+					this.scheduler);
 		}
+
 
 		private void LoginWithConnectionButtonClick ()
 		{
@@ -77,6 +98,26 @@ namespace Auth0Client.iOS.Sample
 							this.scheduler);
 		}
 
+		private void SetResultText(string text)
+		{
+			this.resultElement.Value = text;
+			this.ReloadData ();
+			this.loadingOverlay.Hide ();
+		}
+
+		private void ShowResult(Auth0User user)
+		{
+			var id = user.IdToken;
+			var refreshToken = user.RefreshToken;
+			var profile = user.Profile.ToString();
+
+			var truncatedId = id.Remove (0, 20);
+			truncatedId = truncatedId.Insert (0, "...");
+
+			SetResultText(string.Format ("Id (*Changed): {0}\r\n\r\nRefresh Token: {1}\r\n\r\nProfile:\r\n{2}", 
+				truncatedId, refreshToken, profile));
+		}
+
 		private void ShowResult(Task<Auth0User> taskResult)
 		{
 			Exception error = taskResult.Exception != null ? taskResult.Exception.Flatten () : null;
@@ -85,12 +126,23 @@ namespace Auth0Client.iOS.Sample
 				error = new Exception ("Authentication was canceled.");
 			}
 
-			this.resultElement.Value = error == null ?
+			var refreshToken = error == null ?
+				taskResult.Result.RefreshToken :
+				string.Empty;
+
+			var id = error == null ?
+				taskResult.Result.IdToken :
+				string.Empty;
+
+			var truncatedId = id.Remove (0, 20);
+			truncatedId = truncatedId.Insert (0, "...");
+
+			var profile = error == null ?
 				taskResult.Result.Profile.ToString () :
 				error.InnerException != null ? error.InnerException.Message : error.Message;
-
-			this.ReloadData ();
-			this.loadingOverlay.Hide ();
+				
+			SetResultText(string.Format ("Id: {0}\r\n\r\nRefresh Token: {1}\r\n\r\nProfile:\r\n{2}", 
+				truncatedId, refreshToken, profile));
 		}
 	}
 }

--- a/samples/Auth0Client.iOS.Sample/Auth0Client_iOS_SampleViewController.designer.cs
+++ b/samples/Auth0Client.iOS.Sample/Auth0Client_iOS_SampleViewController.designer.cs
@@ -30,6 +30,9 @@ namespace Auth0Client.iOS.Sample
 			var loginWithConnectionBtn = new StyledStringElement ("Login with Google", this.LoginWithConnectionButtonClick) {
 				Alignment = UITextAlignment.Center
 			};
+			var refreshIdBtn = new StyledStringElement ("Get new ID with Refresh Token", this.RefreshUserId) {
+				Alignment = UITextAlignment.Center
+			};
 
 			var loginBtn = new StyledStringElement ("Login", this.LoginWithUsernamePassword) {
 				Alignment = UITextAlignment.Center
@@ -46,10 +49,14 @@ namespace Auth0Client.iOS.Sample
 			login2.Add (this.passwordElement = new EntryElement ("Password", string.Empty, string.Empty, true));
 			login2.Add (loginBtn);
 
+			var refresh = new Section ("Using refresh token");
+			refresh.Add (refreshIdBtn);
+
 			var result = new Section ("Result");
 			result.Add(this.resultElement);
 
-			this.Root.Add (new Section[] { login1, login2, result });
+			this.Root.Add (new Section[] { login1, login2, refresh, result });
 		}
+
 	}
 }


### PR DESCRIPTION
I have added support for using refresh tokens. I also updated the iOS sample to include a test to get a new id with a refresh token. Note: I only was able to add this support for iOS since I do not have an Android subscription.
