### PR TITLE
Use NuGet for Newtonsoft.JSON

### DIFF
--- a/samples/Auth0Client.Android.Sample/Auth0Client.Android.Sample.csproj
+++ b/samples/Auth0Client.Android.Sample/Auth0Client.Android.Sample.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\android\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -55,6 +55,7 @@
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Properties\AndroidManifest.xml" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Main.axml" />
@@ -62,12 +63,6 @@
     <AndroidResource Include="Resources\drawable\Icon.png" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
-  <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Auth0Client.Android\Auth0Client.Android.csproj">
       <Project>{81864EA2-C020-4B1F-82E5-0634DD071084}</Project>

--- a/samples/Auth0Client.Android.Sample/Resources/Resource.designer.cs
+++ b/samples/Auth0Client.Android.Sample/Resources/Resource.designer.cs
@@ -48,9 +48,6 @@ namespace Auth0Client.Android.Sample
 			// aapt resource value: 0x7f020000
 			public const int Icon = 2130837504;
 			
-			// aapt resource value: 0x7f020001
-			public const int monoandroidsplash = 2130837505;
-			
 			static Drawable()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -64,32 +61,32 @@ namespace Auth0Client.Android.Sample
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f060002
-			public const int loginWithConnection = 2131099650;
+			// aapt resource value: 0x7f050002
+			public const int loginWithConnection = 2131034114;
 			
-			// aapt resource value: 0x7f060005
-			public const int loginWithUserPassword = 2131099653;
+			// aapt resource value: 0x7f050005
+			public const int loginWithUserPassword = 2131034117;
 			
-			// aapt resource value: 0x7f060000
-			public const int loginWithWidget = 2131099648;
+			// aapt resource value: 0x7f050000
+			public const int loginWithWidget = 2131034112;
 			
-			// aapt resource value: 0x7f060001
-			public const int loginWithWidgetAndRefreshToken = 2131099649;
+			// aapt resource value: 0x7f050001
+			public const int loginWithWidgetAndRefreshToken = 2131034113;
 			
-			// aapt resource value: 0x7f060006
-			public const int refreshWithIdToken = 2131099654;
+			// aapt resource value: 0x7f050006
+			public const int refreshWithIdToken = 2131034118;
 			
-			// aapt resource value: 0x7f060007
-			public const int refreshWithRefreshToken = 2131099655;
+			// aapt resource value: 0x7f050007
+			public const int refreshWithRefreshToken = 2131034119;
 			
-			// aapt resource value: 0x7f060008
-			public const int txtResult = 2131099656;
+			// aapt resource value: 0x7f050008
+			public const int txtResult = 2131034120;
 			
-			// aapt resource value: 0x7f060003
-			public const int txtUserName = 2131099651;
+			// aapt resource value: 0x7f050003
+			public const int txtUserName = 2131034115;
 			
-			// aapt resource value: 0x7f060004
-			public const int txtUserPassword = 2131099652;
+			// aapt resource value: 0x7f050004
+			public const int txtUserPassword = 2131034116;
 			
 			static Id()
 			{
@@ -132,22 +129,6 @@ namespace Auth0Client.Android.Sample
 			}
 			
 			private String()
-			{
-			}
-		}
-		
-		public partial class Style
-		{
-			
-			// aapt resource value: 0x7f050000
-			public const int Mono_Android_Theme_Splash = 2131034112;
-			
-			static Style()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Style()
 			{
 			}
 		}

--- a/samples/Auth0Client.Android.Sample/packages.config
+++ b/samples/Auth0Client.Android.Sample/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoAndroid23" />
+</packages>

--- a/samples/Auth0Client.iOS.Sample/Auth0Client.iOS.Sample-Classic.csproj
+++ b/samples/Auth0Client.iOS.Sample/Auth0Client.iOS.Sample-Classic.csproj
@@ -91,7 +91,7 @@
     <Reference Include="monotouch" />
     <Reference Include="MonoTouch.Dialog-1" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\ios\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -115,11 +116,5 @@
       <Project>{73FADD05-A3BA-48A1-BB03-EAA19CA9782B}</Project>
       <Name>Auth0Client.iOS-Classic</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
   </ItemGroup>
 </Project>

--- a/samples/Auth0Client.iOS.Sample/Auth0Client.iOS.Sample.csproj
+++ b/samples/Auth0Client.iOS.Sample/Auth0Client.iOS.Sample.csproj
@@ -92,7 +92,7 @@
     <Reference Include="MonoTouch.Dialog-1" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\ios-unified\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -116,11 +117,5 @@
       <Project>{6D7BCBB4-FA0D-44E6-BFA3-89D166F4DDCB}</Project>
       <Name>Auth0Client.iOS</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
   </ItemGroup>
 </Project>

--- a/samples/Auth0Client.iOS.Sample/packages.config
+++ b/samples/Auth0Client.iOS.Sample/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="xamarinios10" />
+</packages>

--- a/src/Auth0Client.Android/Auth0Client.Android.csproj
+++ b/src/Auth0Client.Android/Auth0Client.Android.csproj
@@ -43,7 +43,7 @@
       <HintPath>..\..\Components\xamarin.auth-1.2.3.1\lib\android\Xamarin.Auth.Android.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\android\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -68,16 +68,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\Strings.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
   <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
     <XamarinComponentReference Include="xamarin.auth">
       <Version>1.2.3.1</Version>
       <Visible>False</Visible>

--- a/src/Auth0Client.Android/packages.config
+++ b/src/Auth0Client.Android/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoAndroid23" />
+</packages>

--- a/src/Auth0Client.iOS/Auth0Client.iOS-Classic.csproj
+++ b/src/Auth0Client.iOS/Auth0Client.iOS-Classic.csproj
@@ -44,7 +44,7 @@
       <HintPath>..\..\Components\xamarin.auth-1.2.3.1\lib\ios\Xamarin.Auth.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\ios\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -71,13 +71,12 @@
     <Compile Include="DeviceIdProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
     <XamarinComponentReference Include="xamarin.auth">
       <Version>1.2.3.1</Version>
       <Visible>False</Visible>
     </XamarinComponentReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/src/Auth0Client.iOS/Auth0Client.iOS.csproj
+++ b/src/Auth0Client.iOS/Auth0Client.iOS.csproj
@@ -36,15 +36,15 @@
     <DefineConstants>PLATFORM_IOS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Components\json.net-4.5.11.1\lib\ios-unified\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Xamarin.Auth.iOS">
       <HintPath>..\..\Components\xamarin.auth-1.2.3.1\lib\ios-unified\Xamarin.Auth.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -72,13 +72,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <XamarinComponentReference Include="json.net">
-      <Version>4.5.11.1</Version>
-      <Visible>False</Visible>
-    </XamarinComponentReference>
     <XamarinComponentReference Include="xamarin.auth">
       <Version>1.2.3.1</Version>
       <Visible>False</Visible>
     </XamarinComponentReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/src/Auth0Client.iOS/packages.config
+++ b/src/Auth0Client.iOS/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="MonoTouch10" />
+</packages>


### PR DESCRIPTION
@siacomuzzi @dschenkelman please review. Using NuGet instead of local copy for JSON dependency.
Tries to address #13 